### PR TITLE
fix edged case bug

### DIFF
--- a/t/001_traverse.t
+++ b/t/001_traverse.t
@@ -27,7 +27,7 @@ sub test_traverse {
     my ($input, $expect) = @specs{qw/input expect/};
 
     subtest $desc => sub {
-        my $context = JSON::Pointer->traverse($document, $input, 0);
+        my $context = JSON::Pointer->traverse($document, $input, +{ strict => 0 });
 
         is($context->result, $expect->{result}, "result");
         is($context->last_token, $expect->{last_token}, "last_token");

--- a/t/002_get.t
+++ b/t/002_get.t
@@ -42,7 +42,7 @@ sub test_get_exception {
     subtest $desc => sub {
         throws_ok {
             eval {
-                JSON::Pointer->get($document, $input, 1);
+                JSON::Pointer->get($document, $input, +{ strict => 1 });
             };
             if (my $e = $@) {
                 is($e->context->last_token, $expect->{last_token}, "last_token");


### PR DESCRIPTION
たとえば

``` perl
JSON::Pointer->move([0,1], '/2', '/1');
# [0, undef, 1]
```

となりますが、配列へのpointerについては、たぶん以下の仕様が正しいと思われます。
- 要素数と同じindexが許容されるのはaddのみ
- その他のopに関しては、該当pointer（removeとreplaceはpath, moveとcopyはfrom）が指し示すindexは要素数未満である必要があり、かつ"-"であってはならない
- testについてはRFCに明示的に書いてないが、たぶんだめ（例外投げるべき）。でも微妙。

boolの引数が複数になるのは微妙かなと思ったので$optsにまとめてしまいました。なおtraverse以外のinterfaceはいじってまてん。
