### PR TITLE
fix precedence

### DIFF
--- a/lib/JSON/Pointer.pm
+++ b/lib/JSON/Pointer.pm
@@ -301,13 +301,13 @@ sub _throw_or_return {
 sub _is_iv_or_nv {
     my $value = shift;
     my $flags = B::svref_2object(\$value)->FLAGS;
-    return ($flags & ( B::SVp_IOK | B::SVp_NOK )) and !($flags & B::SVp_POK);
+    return ( ($flags & ( B::SVp_IOK | B::SVp_NOK )) and !($flags & B::SVp_POK) );
 }
 
 sub _is_pv {
     my $value = shift;
     my $flags = B::svref_2object(\$value)->FLAGS;
-    return !($flags & ( B::SVp_IOK | B::SVp_NOK )) and ($flags & B::SVp_POK);
+    return ( !($flags & ( B::SVp_IOK | B::SVp_NOK )) and ($flags & B::SVp_POK) );
 }
 
 1;


### PR DESCRIPTION
@zigorou さん

優先順位の問題で

```
return ($flags & ( B::SVp_IOK | B::SVp_NOK )) and !($flags & B::SVp_POK);
```

が以下のように解釈されるため、修正しました。

```
return ($flags & ( B::SVp_IOK | B::SVp_NOK ));
```

テストケースを書いていたのですが、SV/IV関連の振る舞いPerlのVersionにより異なるため、
省略させて戴きました。
