### PR TITLE
Topic/support relative json pointer

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl extension JSON::Pointer
 
 {{$NEXT}}
 
+    - Accept ARRAY in JSON::Pointer::Syntax::as_pointer()
+    - Support Relative JSON Pointer in JSON::Pointer::get_relative()
+
 0.06 2014-09-02T14:09:32Z
 
     - Improve JSON primitive type detection (https://github.com/zigorou/perl-json-pointer/pull/7)

--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Perl extension JSON::Pointer
 
     - Accept ARRAY in JSON::Pointer::Syntax::as_pointer()
     - Support Relative JSON Pointer in JSON::Pointer::get_relative()
+    - Fixed issue (https://github.com/zigorou/perl-json-pointer/issues/8)
 
 0.06 2014-09-02T14:09:32Z
 

--- a/lib/JSON/Pointer.pm
+++ b/lib/JSON/Pointer.pm
@@ -346,13 +346,13 @@ sub _throw_or_return {
 sub _is_iv_or_nv {
     my $value = shift;
     my $flags = B::svref_2object(\$value)->FLAGS;
-    return ( ($flags & ( B::SVp_IOK | B::SVp_NOK )) and !($flags & B::SVp_POK) );
+    return ( ($flags & ( B::SVp_IOK | B::SVp_NOK )) && !($flags & B::SVp_POK) );
 }
 
 sub _is_pv {
     my $value = shift;
     my $flags = B::svref_2object(\$value)->FLAGS;
-    return ( !($flags & ( B::SVp_IOK | B::SVp_NOK )) and ($flags & B::SVp_POK) );
+    return ( !($flags & ( B::SVp_IOK | B::SVp_NOK )) && ($flags & B::SVp_POK) );
 }
 
 1;

--- a/lib/JSON/Pointer/Syntax.pm
+++ b/lib/JSON/Pointer/Syntax.pm
@@ -62,14 +62,14 @@ sub tokenize {
 }
 
 sub as_pointer {
-    my ($class, $tokens) = @_;
+    my $class = shift;
+    my @tokens = ref $_[0] eq "ARRAY" ? @$_[0] : @_;
 
-    return @$tokens > 0 ? "/" . join(
+    return @tokens > 0 ? "/" . join(
         "/", 
         map { escape_reference_token($_) }
-        @$tokens
+        @tokens
     ) : "";
-
 }
 
 sub is_array_numeric_index {

--- a/lib/JSON/Pointer/Syntax.pm
+++ b/lib/JSON/Pointer/Syntax.pm
@@ -63,7 +63,7 @@ sub tokenize {
 
 sub as_pointer {
     my $class = shift;
-    my @tokens = ref $_[0] eq "ARRAY" ? @$_[0] : @_;
+    my @tokens = (ref $_[0] eq "ARRAY") ? @{$_[0]} : @_;
 
     return @tokens > 0 ? "/" . join(
         "/", 

--- a/t/010_get_relative.t
+++ b/t/010_get_relative.t
@@ -1,0 +1,94 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use Carp;
+use JSON;
+use JSON::Pointer;
+use JSON::Pointer::Exception qw(:all);
+
+my $document = decode_json(<< "JSON");
+{
+    "foo": ["bar", "baz"],
+    "highly": {
+        "nested": {
+            "objects": true
+        }
+    }
+}
+JSON
+
+sub test_get_relative {
+    my ($desc, %specs) = @_;
+
+    my ($input, $expect) = @specs{qw/input expect/};
+
+    subtest $desc => sub {
+        my $actual = JSON::Pointer->get_relative($document, @$input);
+        is_deeply($actual, $expect, "target");
+    };
+}
+
+subtest "Reletive JSON Pointer examples in 5.1" => sub {
+    subtest "current pointer is /foo/1" => sub {
+        my $current_pointer = "/foo/1";
+        
+        test_get_relative "0" => (
+            input => [ $current_pointer, "0" ],
+            expect => "baz",
+        );
+
+        test_get_relative "1/0" => (
+            input => [ $current_pointer, "1/0" ],
+            expect => "bar",
+        );
+
+        test_get_relative "2/highly/nested/objects" => (
+            input => [ $current_pointer, "2/highly/nested/objects" ],
+            expect => JSON::true,
+        );
+
+        test_get_relative "0#" => (
+            input => [ $current_pointer, "0#" ],
+            expect => 1,
+        );
+
+        test_get_relative "1#" => (
+            input => [ $current_pointer, "1#" ],
+            expect => "foo",
+        );
+    };
+
+    subtest "current pointer is /highly/nested" => sub {
+        my $current_pointer = "/highly/nested";
+        
+        test_get_relative "0/objects" => (
+            input => [ $current_pointer, "0/objects" ],
+            expect => JSON::true,
+        );
+
+        test_get_relative "1/nested/objects" => (
+            input => [ $current_pointer, "1/nested/objects" ],
+            expect => JSON::true,
+        );
+
+        test_get_relative "2/foo/0" => (
+            input => [ $current_pointer, "2/foo/0" ],
+            expect => "bar",
+        );
+
+        test_get_relative "0#" => (
+            input => [ $current_pointer, "0#" ],
+            expect => "nested",
+        );
+
+        test_get_relative "1#" => (
+            input => [ $current_pointer, "1#" ],
+            expect => "highly",
+        );
+    };
+};
+
+done_testing;

--- a/t/syntax/004_as_pointer.t
+++ b/t/syntax/004_as_pointer.t
@@ -5,8 +5,12 @@ use JSON::Pointer::Syntax;
 
 sub test_as_pointer {
     my ($tokens, $expect, $desc) = @_;
-    my $actual = JSON::Pointer::Syntax->as_pointer($tokens);
-    is($actual, $expect, $desc);
+    subtest $desc => sub {
+        my $actual = JSON::Pointer::Syntax->as_pointer($tokens);
+        is($actual, $expect, "arrayref");
+        $actual = JSON::Pointer::Syntax->as_pointer(@$tokens);
+        is($actual, $expect, "array");
+    }
 }
 
 subtest "JSON Pointer Section 5 examples" => sub {


### PR DESCRIPTION
- Accept ARRAY in JSON::Pointer::Syntax::as_pointer()
- Support Relative JSON Pointer in JSON::Pointer::get_relative()
- Fixed issue (https://github.com/zigorou/perl-json-pointer/issues/8)
